### PR TITLE
Switch to an S3 production deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,15 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - add_ssh_keys:
-          finterprints:
-            # Replace this with the fingerprint for your "gh-prod" key.
-            - "b1:be:db:b2:a7:8d:69:c6:41:78:7f:b6:5d:87:ed:5c"
       - attach_workspace:
           at: /tmp/build
       - run:
-          name: Deploy to production Github
-          command: bash scripts/deploy/circleci/deploy_prod.sh
+          name: Install awscli
+          command: sudo pip install awscli
+      - run:
+          name: Deploy to S3
+          command: aws s3 sync --acl public-read --sse --delete /tmp/build/_site s3://sdg-data-test.data.gov
+
 workflows:
   version: 2
   test:

--- a/scripts/deploy/circleci/deploy_prod.sh
+++ b/scripts/deploy/circleci/deploy_prod.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
+# This script deploys the built site to the gh-pages branch of a prod repo.
 git config --global user.email $GH_EMAIL
 git config --global user.name $GH_NAME
 
 # CircleCI will identify the SSH key with a "Host" of gh-prod. In order to tell
 # Git to use this key, we need to hack the SSH key:
 sed -i -e 's/Host gh-prod/Host gh-prod\n  HostName github.com/g' ~/.ssh/config
-git clone git@gh-prod:$GH_ORG_PROD/sdg-data-usa.git out
+# Now we can use "gh-prod" below to identify the SSH key to use.
+git clone git@gh-prod:$GH_ORG_PROD/$GH_ORG_PROD.github.io.git out
 
 cd out
 git checkout master || git checkout --orphan master
 git rm -rfq .
 cd ..
 
-# The fully built site is already available at /tmp/build.
+# The fully built site is already available at /tmp/build/_site.
 cp -a /tmp/build/_site/. out/.
 
 mkdir -p out/.circleci && cp -a .circleci/. out/.circleci/.

--- a/scripts/deploy/circleci/deploy_staging.sh
+++ b/scripts/deploy/circleci/deploy_staging.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
+# This script deploys the built site to the gh-pages branch of the same repo.
 git config --global user.email $GH_EMAIL
 git config --global user.name $GH_NAME
 
 # CircleCI will identify the SSH key with a "Host" of gh-stg. In order to tell
 # Git to use this key, we need to hack the SSH key:
 sed -i -e 's/Host gh-stg/Host gh-stg\n  HostName github.com/g' ~/.ssh/config
-git clone git@gh-stg:$GH_ORG_STG/sdg-data-usa.git out
+# Now we can use "gh-stg" below to identify the SSH key to use.
+git clone git@gh-stg:$GH_ORG_STG/$CIRCLE_PROJECT_REPONAME.git out
 
 cd out
 git checkout gh-pages || git checkout --orphan gh-pages
 git rm -rfq .
 cd ..
 
-# The fully built site is already available at /tmp/build.
+# The fully built site is already available at /tmp/build/_site.
 cp -a /tmp/build/_site/. out/.
 
 mkdir -p out/.circleci && cp -a .circleci/. out/.circleci/.


### PR DESCRIPTION
This is along the same lines as https://github.com/GSA/sdg-indicators-usa/pull/2

Similarly, CircleCI needs to environment variables added:
* AWS_ACCESS_KEY_ID
* AWS_SECRET_ACCESS_KEY

And in order to test this, either an S3 bucket named "sdg-data-test.data.gov" will need to be created, or this PR will need to be updated to point to another bucket.