### PR TITLE
Various schema fixes.

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -173,6 +173,21 @@ prose:
             element: hidden
             label: "Indicator number"
             scope: data
+      - name: "indicator_sort_order"
+        field:
+            element: hidden
+            label: "Indicator Sort Order"
+            scope: data
+      - name: "has_metadata"
+        field:
+            element: hidden
+            label: "Has metadata"
+            scope: data
+      - name: "national_geographical_coverage"
+        field:
+            element: hidden
+            label: "National Geographical Coverage"
+            scope: data
       - name: "target_id"
         field:
             element: text
@@ -230,13 +245,8 @@ prose:
       ######### Chart Info #########
       - name: "graph_type"
         field:
-            element: select
+            element: hidden
             label: "Graph type"
-            options:
-              - name: 'line'
-                value: 'line'
-              - name: 'bar'
-                value: 'bar'
             scope: graph
       - name: "graph_title"
         field:
@@ -297,7 +307,7 @@ prose:
             element: checkbox
             label: Source 2 active
             help: Whether or not to display this source
-            value: true
+            value: false
       - name: source_organisation_2
         field:
             element: text


### PR DESCRIPTION
This includes the following changes:
* Adds schema entries for "indicator_sort_order", "has_metadata", and "national_geographical_coverage", all set to HIDDEN so that they won't display in Prose.io. This change simply prevents them from appearing in the "Raw metadata" field in Prose.
* Changes the graph_type field to HIDDEN so that it can't be edited in Prose.io.
* Changes the source_active_2 field to default to FALSE instead of TRUE. Without this change, when data providers make changes, this checkbox will default to TRUE and a second source will appear on the site, with all empty fields.