### PR TITLE
Bust the CircleCI cache, since code has changed in sdg-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: test-dependencies-v1-{{ checksum "scripts/requirements.txt" }}
+          key: test-dependencies-v2-{{ checksum "scripts/requirements.txt" }}
       - run:
           name: Install Python dependencies
           command: |
@@ -16,7 +16,7 @@ jobs:
             . venv/bin/activate
             pip install -r scripts/requirements.txt
       - save_cache:
-          key: test-dependencies-v1-{{ checksum "scripts/requirements.txt" }}
+          key: test-dependencies-v2-{{ checksum "scripts/requirements.txt" }}
           paths:
             - ./venv
       - run:


### PR DESCRIPTION
Code was added to the sdg-build fork to allow for the new "binary" graph type. But CircleCI is still using a cached version of the server. This should force CircleCI to grab the latest code from the sdg-build library.