### PR TITLE
Require test job before build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,16 +93,16 @@ jobs:
           command: bash scripts/deploy/circleci/deploy_prod.sh
 workflows:
   version: 2
-  test:
+  build-deploy:
     jobs:
       - test:
           filters:
             branches:
               ignore:
                 - gh-pages
-  build-deploy:
-    jobs:
       - build:
+          requires:
+            - test
           filters:
             branches:
               only:


### PR DESCRIPTION
Right now the "test" and "build" jobs are happening simultaneously, because they are in separate workflows. This means that even if the tests fail, the build will still happen.

This change puts them in the same workflow, which should abort the build if the tests fail.