### PR TITLE
Deploy to subfolders of the gh-pages branch instead of in the root.

### DIFF
--- a/scripts/deploy/circleci/deploy_prod.sh
+++ b/scripts/deploy/circleci/deploy_prod.sh
@@ -1,25 +1,20 @@
 #!/usr/bin/env bash
-# This script deploys the built site to the prod-pages branch of the same repo.
-git config --global user.email $GH_EMAIL
-git config --global user.name $GH_NAME
+# This script deploys the built site to a subfolder of the gh-pages branch.
+git config --global user.email "$GH_EMAIL"
+git config --global user.name "$GH_NAME"
 
-# CircleCI will identify the SSH key with a "Host" of gh-prod. In order to tell
+# CircleCI will identify the SSH key with a "Host" of gh-stg. In order to tell
 # Git to use this key, we need to hack the SSH key:
 sed -i -e 's/Host gh-stg/Host gh-stg\n  HostName github.com/g' ~/.ssh/config
 git clone git@gh-stg:$GH_ORG_STG/$CIRCLE_PROJECT_REPONAME.git out
 
 cd out
-git checkout prod-pages || git checkout --orphan prod-pages
-git rm -rfq .
-cd ..
-
-# The fully built site is already available at /tmp/build.
-cp -a /tmp/build/_site/. out/.
-
-mkdir -p out/.circleci && cp -a .circleci/. out/.circleci/.
-cd out
+git checkout gh-pages || git checkout --orphan gh-pages
+# Clear the "prod" subfolder and copy the built site into it.
+git rm -rfq prod
+cp -a /tmp/build/_site prod
 
 git add -A
 git commit -m "Automated deployment to GitHub Pages: ${CIRCLE_SHA1}" --allow-empty
 
-git push origin prod-pages
+git push origin gh-pages

--- a/scripts/deploy/circleci/deploy_staging.sh
+++ b/scripts/deploy/circleci/deploy_staging.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# This script deploys the built site to the gh-pages branch of the same repo.
-git config --global user.email $GH_EMAIL
-git config --global user.name $GH_NAME
+# This script deploys the built site to a subfolder of the gh-pages branch.
+git config --global user.email "$GH_EMAIL"
+git config --global user.name "$GH_NAME"
 
 # CircleCI will identify the SSH key with a "Host" of gh-stg. In order to tell
 # Git to use this key, we need to hack the SSH key:
@@ -10,14 +10,9 @@ git clone git@gh-stg:$GH_ORG_STG/$CIRCLE_PROJECT_REPONAME.git out
 
 cd out
 git checkout gh-pages || git checkout --orphan gh-pages
-git rm -rfq .
-cd ..
-
-# The fully built site is already available at /tmp/build.
-cp -a /tmp/build/_site/. out/.
-
-mkdir -p out/.circleci && cp -a .circleci/. out/.circleci/.
-cd out
+# Clear the "staging" subfolder and copy the built site into it.
+git rm -rfq staging
+cp -a /tmp/build/_site staging
 
 git add -A
 git commit -m "Automated deployment to GitHub Pages: ${CIRCLE_SHA1}" --allow-empty


### PR DESCRIPTION
This will allow both staging data and production data to exist on the same Github Pages site:
* gsa.github.io/sdg-data-usa/staging
* gsa.github.io/sdg-data-usa/prod

After this is merged into develop, develop should be merged into master.