### PR TITLE
Switch to open-sdg/sdg-build version 0.3.0

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -198,12 +198,12 @@ prose:
             element: select
             label: "Reporting status"
             options:
-              - name: 'notstarted'
-                value: 'notstarted'
-              - name: 'inprogress'
-                value: 'inprogress'
               - name: 'complete'
                 value: 'complete'
+              - name: 'inprogress'
+                value: 'inprogress'
+              - name: 'notstarted'
+                value: 'notstarted'
             scope: data
       - name: data_non_statistical
         field:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,5 +3,5 @@ pandas
 gitpython
 ruamel.yaml>=0.15
 git+git://github.com/dougmet/yamlmd
-git+git://github.com/open-sdg/sdg-build@0.2.0
+git+git://github.com/open-sdg/sdg-build@0.3.0
 python-frontmatter

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,5 +3,5 @@ pandas
 gitpython
 ruamel.yaml>=0.15
 git+git://github.com/dougmet/yamlmd
-git+git://github.com/brockfanning/sdg-build@multilingual-meta#egg=sdg
+git+git://github.com/open-sdg/sdg-build@0.2.0
 python-frontmatter


### PR DESCRIPTION
This updates and pins to sdg-build 0.3.0.

Also this re-arranges the options for the reporting status Prose.io field, in preparation for Open SDG 0.5.0, when that order is actually going to determine the order they appear on the reporting status page.